### PR TITLE
Fix connection pool exhaustion by closing broken connections

### DIFF
--- a/bot/db/repository.py
+++ b/bot/db/repository.py
@@ -33,7 +33,12 @@ def _query(sql: str, params: tuple) -> list[tuple]:
         with conn.cursor() as cur:
             cur.execute(sql, params)
             return cur.fetchall()
-    finally:
+    except Exception:
+        # Connection may be in a bad state (broken pipe, transaction aborted,
+        # etc.).  Close it so the pool replaces it with a fresh one next time.
+        db_pool.putconn(conn, close=True)
+        raise
+    else:
         db_pool.putconn(conn)
 
 


### PR DESCRIPTION
## Changes

- Modified exception handling in `_query()` to detect and properly handle broken database connections
- When an exception occurs during query execution, the connection is now explicitly closed before being returned to the pool
- This prevents broken connections (due to broken pipes, aborted transactions, etc.) from being reused, allowing the pool to replace them with fresh connections
- Normal successful queries continue to return connections to the pool without closing them

## Fixes

Prevents connection pool exhaustion caused by accumulation of broken connections that would otherwise remain in the pool.