### PR TITLE
Fix missing cc_profiles.yaml in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN uv sync --frozen --no-dev --no-install-project
 
 COPY main.py .
 COPY bot/ bot/
+COPY data/ data/
 
 RUN useradd --create-home appuser \
     && chown -R appuser:appuser /app


### PR DESCRIPTION
## Summary
- Add `COPY data/ data/` to Dockerfile so `cc_profiles.yaml` is included in the container image at `/app/data/cc_profiles.yaml`

## Root Cause
The Dockerfile copied `bot/` and `main.py` but never copied the `data/` directory, so `cc_profiles.yaml` was missing at runtime in the container. The CC voter-hash → X-handle lookup always failed with a "CC profile file not found" warning.

## Test plan
- [x] All tests pass
- [x] Deployed and verified `cc_profiles.yaml` is present at `/app/data/cc_profiles.yaml`

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)