### PR TITLE
Renew SSH DB tunnel when invalidated

### DIFF
--- a/bot/db/repository.py
+++ b/bot/db/repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 
 import psycopg
 
@@ -13,11 +14,16 @@ from bot.db.queries import (
     QUERY_GOV_ACTIONS,
     QUERY_TREASURY_DONATIONS,
 )
+from bot.logging import get_logger
 from bot.models import CcVote, GovAction, TreasuryDonation
+
+logger = get_logger("db_repository")
 
 _conn: psycopg.AsyncConnection | None = None
 _lock = asyncio.Lock()
 _effective_db_url: str = config.db_sync_url
+_db_url_provider: Callable[[], str] | None = None
+_conn_db_url: str | None = None
 
 
 def set_db_url(url: str) -> None:
@@ -26,15 +32,63 @@ def set_db_url(url: str) -> None:
     _effective_db_url = url
 
 
+def set_db_url_provider(provider: Callable[[], str] | None) -> None:
+    """Set a callable that returns the current effective DB URL."""
+    global _db_url_provider
+    _db_url_provider = provider
+
+
+def _resolve_db_url() -> str:
+    """Return the current DB URL, consulting the provider when configured."""
+    global _effective_db_url
+    if _db_url_provider is not None:
+        _effective_db_url = _db_url_provider()
+    return _effective_db_url
+
+
+async def _reset_conn() -> None:
+    """Close and clear the shared connection, ignoring close errors."""
+    global _conn, _conn_db_url
+    conn = _conn
+    _conn = None
+    _conn_db_url = None
+    if conn is None or conn.closed:
+        return
+    try:
+        await conn.close()
+    except Exception:
+        logger.warning("Failed to close database connection cleanly", exc_info=True)
+
+
 async def _get_conn() -> psycopg.AsyncConnection:
     """Return the shared connection, creating it lazily on first use."""
-    global _conn
-    if _conn is None or _conn.closed:
-        _conn = await psycopg.AsyncConnection.connect(
-            conninfo=_effective_db_url,
-            autocommit=True,
-        )
+    global _conn, _conn_db_url
+    db_url = _resolve_db_url()
+    if _conn is not None and not _conn.closed and _conn_db_url == db_url:
+        return _conn
+
+    if _conn is not None:
+        await _reset_conn()
+
+    _conn = await psycopg.AsyncConnection.connect(
+        conninfo=db_url,
+        autocommit=True,
+    )
+    _conn_db_url = db_url
     return _conn
+
+
+async def close_conn() -> None:
+    """Close the shared connection, if open."""
+    async with _lock:
+        await _reset_conn()
+
+
+async def _query_once(sql: str, params: tuple) -> list[tuple]:
+    conn = await _get_conn()
+    async with conn.cursor() as cur:
+        await cur.execute(sql, params)
+        return await cur.fetchall()
 
 
 async def _query(sql: str, params: tuple) -> list[tuple]:
@@ -42,20 +96,23 @@ async def _query(sql: str, params: tuple) -> list[tuple]:
 
     Acquires the shared lock so only one query runs at a time.
     Other callers await the lock asynchronously (non-blocking).
+    Retries once after resetting the shared connection, which is safe because
+    all repository queries are read-only.
     """
     async with _lock:
-        conn = await _get_conn()
-        try:
-            async with conn.cursor() as cur:
-                await cur.execute(sql, params)
-                return await cur.fetchall()
-        except Exception:
-            # Connection may be in a bad state.  Close it so the next
-            # call to _get_conn() creates a fresh one.
-            global _conn
-            await conn.close()
-            _conn = None
-            raise
+        for attempt in range(2):
+            try:
+                return await _query_once(sql, params)
+            except psycopg.Error:
+                await _reset_conn()
+                if attempt == 0:
+                    logger.warning("Database query failed; resetting connection and retrying once", exc_info=True)
+                    continue
+                raise
+            except Exception:
+                await _reset_conn()
+                raise
+    raise RuntimeError("Database query retry loop exited unexpectedly")
 
 
 async def get_gov_actions(block_no: int) -> list[GovAction]:

--- a/bot/db/ssh_tunnel.py
+++ b/bot/db/ssh_tunnel.py
@@ -32,10 +32,7 @@ class SshTunnel:
         """Return whether the local listener and SSH transport are both usable."""
         transport = self.ssh_client.get_transport()
         return (
-            self._server is not None
-            and self._server.fileno() != -1
-            and transport is not None
-            and transport.is_active()
+            self._server is not None and self._server.fileno() != -1 and transport is not None and transport.is_active()
         )
 
     def stop(self) -> None:

--- a/bot/db/ssh_tunnel.py
+++ b/bot/db/ssh_tunnel.py
@@ -28,9 +28,23 @@ class SshTunnel:
         self.local_bind_port = local_port
         self._server: socket.socket | None = None
 
+    def is_active(self) -> bool:
+        """Return whether the local listener and SSH transport are both usable."""
+        transport = self.ssh_client.get_transport()
+        return (
+            self._server is not None
+            and self._server.fileno() != -1
+            and transport is not None
+            and transport.is_active()
+        )
+
     def stop(self) -> None:
         if self._server is not None:
-            self._server.close()
+            try:
+                self._server.close()
+            except OSError:
+                pass
+            self._server = None
         self.ssh_client.close()
 
 
@@ -70,11 +84,33 @@ def _accept_loop(
             # Server socket closed — tunnel is stopping.
             break
         try:
+            if not transport.is_active():
+                logger.warning(
+                    "SSH transport became inactive; stopping local forwarder for %s:%s",
+                    remote_host,
+                    remote_port,
+                )
+                client_sock.close()
+                server.close()
+                break
             channel = transport.open_channel(
                 "direct-tcpip",
                 (remote_host, remote_port),
                 addr,
             )
+        except paramiko.SSHException:
+            if not transport.is_active():
+                logger.warning(
+                    "SSH transport became inactive while opening channel; stopping local forwarder for %s:%s",
+                    remote_host,
+                    remote_port,
+                )
+                client_sock.close()
+                server.close()
+                break
+            logger.exception("Failed to open SSH channel to %s:%s", remote_host, remote_port)
+            client_sock.close()
+            continue
         except Exception:
             logger.exception("Failed to open SSH channel to %s:%s", remote_host, remote_port)
             client_sock.close()
@@ -82,7 +118,7 @@ def _accept_loop(
         threading.Thread(target=_forward, args=(client_sock, channel), daemon=True).start()
 
 
-def start_tunnel(cfg: Config) -> SshTunnel:
+def start_tunnel(cfg: Config, *, local_port: int | None = None) -> SshTunnel:
     """Start an SSH tunnel forwarding a local port to the remote DB.
 
     Parses ``cfg.db_sync_url`` to extract the remote DB host/port and
@@ -99,16 +135,20 @@ def start_tunnel(cfg: Config) -> SshTunnel:
         port=cfg.ssh_port,
         username=cfg.ssh_user,
         key_filename=cfg.ssh_key_path,
+        timeout=30,
+        banner_timeout=30,
+        auth_timeout=30,
     )
 
     server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    server.bind(("127.0.0.1", 0))
+    server.bind(("127.0.0.1", local_port or 0))
     server.listen(5)
     local_port = server.getsockname()[1]
 
     transport = client.get_transport()
     assert transport is not None
+    transport.set_keepalive(30)
 
     threading.Thread(
         target=_accept_loop,
@@ -138,3 +178,48 @@ def get_tunneled_url(cfg: Config, tunnel: SshTunnel) -> str:
     else:
         netloc = f"{parsed.username}@{local}"
     return urlunparse(parsed._replace(netloc=netloc))
+
+
+class SshTunnelManager:
+    """Own the SSH tunnel and recreate it when the transport drops."""
+
+    def __init__(self, cfg: Config) -> None:
+        self._cfg = cfg
+        self._lock = threading.Lock()
+        self._tunnel: SshTunnel | None = None
+
+    def ensure_active(self) -> SshTunnel:
+        """Return an active tunnel, recreating it if necessary."""
+        with self._lock:
+            if self._tunnel is not None and self._tunnel.is_active():
+                return self._tunnel
+
+            preferred_port = self._tunnel.local_bind_port if self._tunnel is not None else None
+            if self._tunnel is not None:
+                logger.warning("SSH tunnel is inactive; recreating it")
+                self._tunnel.stop()
+                self._tunnel = None
+
+            try:
+                self._tunnel = start_tunnel(self._cfg, local_port=preferred_port)
+            except OSError:
+                if preferred_port is None:
+                    raise
+                logger.warning(
+                    "Could not rebind SSH tunnel on local port %s; allocating a new port",
+                    preferred_port,
+                    exc_info=True,
+                )
+                self._tunnel = start_tunnel(self._cfg)
+
+            return self._tunnel
+
+    def get_tunneled_url(self) -> str:
+        """Return the DB URL routed through the current active tunnel."""
+        return get_tunneled_url(self._cfg, self.ensure_active())
+
+    def stop(self) -> None:
+        with self._lock:
+            if self._tunnel is not None:
+                self._tunnel.stop()
+                self._tunnel = None

--- a/bot/main.py
+++ b/bot/main.py
@@ -40,19 +40,25 @@ config.validate()
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage SSH tunnel lifecycle (if configured)."""
-    tunnel = None
+    tunnel_manager = None
+    from bot.db.repository import close_conn, set_db_url_provider
+
     if config.ssh_host:
         from bot.db.repository import set_db_url
-        from bot.db.ssh_tunnel import get_tunneled_url, start_tunnel
+        from bot.db.ssh_tunnel import SshTunnelManager
 
-        tunnel = start_tunnel(config)
-        set_db_url(get_tunneled_url(config, tunnel))
+        tunnel_manager = SshTunnelManager(config)
+        set_db_url_provider(tunnel_manager.get_tunneled_url)
+        set_db_url(tunnel_manager.get_tunneled_url())
 
-    yield
-
-    if tunnel is not None:
-        tunnel.stop()
-        logger.info("SSH tunnel stopped")
+    try:
+        yield
+    finally:
+        await close_conn()
+        set_db_url_provider(None)
+        if tunnel_manager is not None:
+            tunnel_manager.stop()
+            logger.info("SSH tunnel stopped")
 
 
 app = FastAPI(lifespan=lifespan)

--- a/tests/test_db_recovery.py
+++ b/tests/test_db_recovery.py
@@ -1,0 +1,152 @@
+import psycopg
+import pytest
+
+from bot.config import Config
+from bot.db import repository, ssh_tunnel
+
+
+class _FakeCursor:
+    def __init__(self, *, rows=None, error: Exception | None = None):
+        self._rows = rows or []
+        self._error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, _sql, _params):
+        if self._error is not None:
+            raise self._error
+
+    async def fetchall(self):
+        return self._rows
+
+
+class _FakeConn:
+    def __init__(self, cursor: _FakeCursor):
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self):
+        return self._cursor
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeTunnel:
+    def __init__(self, local_bind_port: int):
+        self.local_bind_port = local_bind_port
+        self.active = True
+        self.stopped = False
+
+    def is_active(self) -> bool:
+        return self.active
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.fixture(autouse=True)
+def reset_repository_state():
+    repository._conn = None
+    repository._conn_db_url = None
+    repository._effective_db_url = "postgresql://localhost/test"
+    repository._db_url_provider = None
+    yield
+    repository._conn = None
+    repository._conn_db_url = None
+    repository._effective_db_url = "postgresql://localhost/test"
+    repository._db_url_provider = None
+
+
+@pytest.mark.asyncio
+async def test_query_retries_once_after_connection_error(monkeypatch):
+    connections = [
+        _FakeConn(_FakeCursor(error=psycopg.OperationalError("boom"))),
+        _FakeConn(_FakeCursor(rows=[("ok",)])),
+    ]
+    get_conn_calls = 0
+    reset_calls = 0
+
+    async def fake_get_conn():
+        nonlocal get_conn_calls
+        conn = connections[get_conn_calls]
+        get_conn_calls += 1
+        return conn
+
+    async def fake_reset_conn():
+        nonlocal reset_calls
+        reset_calls += 1
+
+    monkeypatch.setattr(repository, "_get_conn", fake_get_conn)
+    monkeypatch.setattr(repository, "_reset_conn", fake_reset_conn)
+
+    rows = await repository._query("select 1", ())
+
+    assert rows == [("ok",)]
+    assert get_conn_calls == 2
+    assert reset_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_get_conn_reconnects_when_db_url_changes(monkeypatch):
+    urls = iter(
+        [
+            "postgresql://user:pass@127.0.0.1:41001/db",
+            "postgresql://user:pass@127.0.0.1:41002/db",
+        ]
+    )
+    first_conn = _FakeConn(_FakeCursor())
+    second_conn = _FakeConn(_FakeCursor())
+    connect_calls = []
+
+    repository.set_db_url_provider(lambda: next(urls))
+
+    async def fake_connect(*, conninfo, autocommit):
+        assert autocommit is True
+        connect_calls.append(conninfo)
+        return first_conn if len(connect_calls) == 1 else second_conn
+
+    monkeypatch.setattr(repository.psycopg.AsyncConnection, "connect", fake_connect)
+
+    first = await repository._get_conn()
+    second = await repository._get_conn()
+
+    assert first is first_conn
+    assert second is second_conn
+    assert first_conn.closed is True
+    assert connect_calls == [
+        "postgresql://user:pass@127.0.0.1:41001/db",
+        "postgresql://user:pass@127.0.0.1:41002/db",
+    ]
+
+
+def test_tunnel_manager_restarts_with_previous_local_port(monkeypatch):
+    cfg = Config(
+        db_sync_url="postgresql://user:pass@db.internal:5432/gov",
+        ssh_host="bastion.internal",
+        ssh_user="cardano",
+        ssh_key_path="/tmp/key",
+    )
+    first_tunnel = _FakeTunnel(local_bind_port=43123)
+    second_tunnel = _FakeTunnel(local_bind_port=43123)
+    start_calls = []
+
+    def fake_start_tunnel(_cfg, *, local_port=None):
+        start_calls.append(local_port)
+        return first_tunnel if len(start_calls) == 1 else second_tunnel
+
+    monkeypatch.setattr(ssh_tunnel, "start_tunnel", fake_start_tunnel)
+
+    manager = ssh_tunnel.SshTunnelManager(cfg)
+
+    assert manager.ensure_active() is first_tunnel
+
+    first_tunnel.active = False
+
+    assert manager.ensure_active() is second_tunnel
+    assert start_calls == [None, 43123]
+    assert first_tunnel.stopped is True


### PR DESCRIPTION
## Summary
- recreate the SSH tunnel when the Paramiko transport drops instead of continuing to use a dead forwarder
- refresh the shared psycopg connection when the tunneled DB URL changes and retry read queries once after connection reset
- add recovery tests covering tunnel restart, DB URL refresh, and query retry behavior

## Testing
- uv run python -m pytest -q