### PR TITLE
Show required ratification thresholds on new governance-action tweets

### DIFF
--- a/bot/db/queries.py
+++ b/bot/db/queries.py
@@ -49,6 +49,77 @@ QUERY_BLOCK_EPOCH = """
     WHERE b.hash = decode(%s, 'hex')
 """
 
+QUERY_LATEST_THRESHOLDS = """
+    SELECT
+        dvt_motion_no_confidence,
+        dvt_committee_normal,
+        dvt_committee_no_confidence,
+        dvt_update_to_constitution,
+        dvt_hard_fork_initiation,
+        dvt_p_p_network_group,
+        dvt_p_p_economic_group,
+        dvt_p_p_technical_group,
+        dvt_p_p_gov_group,
+        dvt_treasury_withdrawal,
+        pvt_motion_no_confidence,
+        pvt_committee_normal,
+        pvt_committee_no_confidence,
+        pvt_hard_fork_initiation,
+        pvtpp_security_group
+    FROM epoch_param
+    ORDER BY epoch_no DESC
+    LIMIT 1
+"""
+
+# Approval ratio of the currently active Constitutional Committee. Prefers the
+# most recently enacted committee, falling back to the genesis committee
+# (gov_action_proposal_id IS NULL). Pending (un-enacted) committee proposals
+# are excluded.
+QUERY_ACTIVE_COMMITTEE_QUORUM = """
+    SELECT c.quorum_numerator::float8 / NULLIF(c.quorum_denominator, 0)
+    FROM committee c
+    LEFT JOIN gov_action_proposal gap ON c.gov_action_proposal_id = gap.id
+    WHERE c.gov_action_proposal_id IS NULL OR gap.enacted_epoch IS NOT NULL
+    ORDER BY gap.enacted_epoch DESC NULLS LAST, c.id DESC
+    LIMIT 1
+"""
+
+
+def _group_predicate(columns: tuple[str, ...]) -> str:
+    """Build a SQL boolean: true when any of the given pp columns is set."""
+    return "(" + " OR ".join(f"pp.{c} IS NOT NULL" for c in columns) + ")"
+
+
+def build_param_change_groups_query() -> str:
+    """SQL returning which protocol-parameter groups a ParameterChange touches.
+
+    Identified by the action's tx hash (hex) and index. Returns one row of five
+    booleans (network, economic, technical, governance, security).
+    """
+    from bot.thresholds import (
+        ECONOMIC_PARAMS,
+        GOVERNANCE_PARAMS,
+        NETWORK_PARAMS,
+        SECURITY_PARAMS,
+        TECHNICAL_PARAMS,
+    )
+
+    return f"""
+    SELECT
+        {_group_predicate(NETWORK_PARAMS)} AS network,
+        {_group_predicate(ECONOMIC_PARAMS)} AS economic,
+        {_group_predicate(TECHNICAL_PARAMS)} AS technical,
+        {_group_predicate(GOVERNANCE_PARAMS)} AS governance,
+        {_group_predicate(SECURITY_PARAMS)} AS security
+    FROM gov_action_proposal gap
+    JOIN tx t ON gap.tx_id = t.id
+    LEFT JOIN param_proposal pp ON gap.param_proposal = pp.id
+    WHERE t.hash = decode(%s, 'hex') AND gap.index = %s
+    """
+
+
+QUERY_PARAM_CHANGE_GROUPS = build_param_change_groups_query()
+
 QUERY_ALL_GOV_ACTIONS = """
     SELECT
         encode(t.hash, 'hex') AS tx_hash,

--- a/bot/db/repository.py
+++ b/bot/db/repository.py
@@ -23,6 +23,7 @@ from bot.thresholds import (
     EpochThresholds,
     GovThresholds,
     ParamChangeGroups,
+    ThresholdContext,
     compute_thresholds,
 )
 
@@ -166,26 +167,35 @@ async def _get_param_change_groups(action: GovAction) -> ParamChangeGroups | Non
     )
 
 
-async def get_gov_thresholds(action: GovAction) -> GovThresholds | None:
-    """Return the ratification thresholds applicable to a governance action.
+async def get_threshold_context() -> ThresholdContext | None:
+    """Fetch the block-level voting context (epoch thresholds + committee quorum).
 
-    Reads live protocol parameters and committee quorum from DB-Sync. Returns
-    ``None`` if thresholds are unavailable (e.g. pre-Conway data), so callers
-    can omit the line rather than show wrong numbers.
+    These values are identical for every action in a block, so callers should
+    fetch this once per block and pass it to :func:`get_gov_thresholds` for each
+    action. Returns ``None`` if thresholds are unavailable (e.g. pre-Conway
+    data), so callers can omit the thresholds line rather than show wrong numbers.
     """
     params = await _get_epoch_thresholds()
     if params is None:
         return None
-
     committee_quorum = await _get_committee_quorum()
+    return ThresholdContext(params=params, committee_quorum=committee_quorum)
+
+
+async def get_gov_thresholds(action: GovAction, context: ThresholdContext) -> GovThresholds:
+    """Return the ratification thresholds applicable to a single governance action.
+
+    Reuses the shared ``context`` (so the epoch/committee reads happen once per
+    block) and only queries per-action data for ParameterChange group detection.
+    """
     param_groups = None
     if action.action_type == "ParameterChange":
         param_groups = await _get_param_change_groups(action)
 
     return compute_thresholds(
         action.action_type,
-        params,
-        committee_quorum,
+        context.params,
+        context.committee_quorum,
         param_groups=param_groups,
     )
 

--- a/bot/db/repository.py
+++ b/bot/db/repository.py
@@ -7,15 +7,24 @@ import psycopg
 
 from bot.config import config
 from bot.db.queries import (
+    QUERY_ACTIVE_COMMITTEE_QUORUM,
     QUERY_ALL_CC_VOTES,
     QUERY_ALL_GOV_ACTIONS,
     QUERY_BLOCK_EPOCH,
     QUERY_CC_VOTES,
     QUERY_GOV_ACTIONS,
+    QUERY_LATEST_THRESHOLDS,
+    QUERY_PARAM_CHANGE_GROUPS,
     QUERY_TREASURY_DONATIONS,
 )
 from bot.logging import get_logger
 from bot.models import CcVote, GovAction, TreasuryDonation
+from bot.thresholds import (
+    EpochThresholds,
+    GovThresholds,
+    ParamChangeGroups,
+    compute_thresholds,
+)
 
 logger = get_logger("db_repository")
 
@@ -126,6 +135,59 @@ async def get_gov_actions(block_no: int) -> list[GovAction]:
         )
         for row in rows
     ]
+
+
+async def _get_epoch_thresholds() -> EpochThresholds | None:
+    """Fetch the current epoch's governance voting thresholds."""
+    rows = await _query(QUERY_LATEST_THRESHOLDS, ())
+    if not rows:
+        return None
+    return EpochThresholds(*rows[0])
+
+
+async def _get_committee_quorum() -> float | None:
+    """Fetch the active Constitutional Committee's approval ratio."""
+    rows = await _query(QUERY_ACTIVE_COMMITTEE_QUORUM, ())
+    return rows[0][0] if rows and rows[0] else None
+
+
+async def _get_param_change_groups(action: GovAction) -> ParamChangeGroups | None:
+    """Fetch which protocol-parameter groups a ParameterChange action touches."""
+    rows = await _query(QUERY_PARAM_CHANGE_GROUPS, (action.tx_hash, action.index))
+    if not rows:
+        return None
+    network, economic, technical, governance, security = rows[0]
+    return ParamChangeGroups(
+        network=bool(network),
+        economic=bool(economic),
+        technical=bool(technical),
+        governance=bool(governance),
+        security=bool(security),
+    )
+
+
+async def get_gov_thresholds(action: GovAction) -> GovThresholds | None:
+    """Return the ratification thresholds applicable to a governance action.
+
+    Reads live protocol parameters and committee quorum from DB-Sync. Returns
+    ``None`` if thresholds are unavailable (e.g. pre-Conway data), so callers
+    can omit the line rather than show wrong numbers.
+    """
+    params = await _get_epoch_thresholds()
+    if params is None:
+        return None
+
+    committee_quorum = await _get_committee_quorum()
+    param_groups = None
+    if action.action_type == "ParameterChange":
+        param_groups = await _get_param_change_groups(action)
+
+    return compute_thresholds(
+        action.action_type,
+        params,
+        committee_quorum,
+        param_groups=param_groups,
+    )
 
 
 async def get_cc_votes(block_no: int) -> list[CcVote]:

--- a/bot/main.py
+++ b/bot/main.py
@@ -12,6 +12,7 @@ from bot.db.repository import (
     get_cc_votes,
     get_gov_actions,
     get_gov_thresholds,
+    get_threshold_context,
     get_treasury_donations,
 )
 from bot.logging import get_logger, setup_logging
@@ -77,6 +78,10 @@ async def _process_gov_actions(block_no: int) -> None:
         logger.info("No gov actions for block: %s", block_no)
         return
 
+    # Epoch thresholds + committee quorum are the same for every action in the
+    # block, so fetch them once here and reuse per action.
+    threshold_context = await get_threshold_context()
+
     for action in actions:
         url = sanitise_url(action.raw_url)
         metadata = fetch_metadata(url)
@@ -86,7 +91,7 @@ async def _process_gov_actions(block_no: int) -> None:
         for w in warnings:
             logger.warning("CIP-0108 validation [%s#%s]: %s", action.tx_hash[:8], action.index, w)
 
-        thresholds = await get_gov_thresholds(action)
+        thresholds = await get_gov_thresholds(action, threshold_context) if threshold_context else None
 
         tweet = format_gov_action_tweet(action, metadata, thresholds)
         tweet_id = post_tweet(tweet)

--- a/bot/main.py
+++ b/bot/main.py
@@ -11,6 +11,7 @@ from bot.db.repository import (
     get_block_epoch,
     get_cc_votes,
     get_gov_actions,
+    get_gov_thresholds,
     get_treasury_donations,
 )
 from bot.logging import get_logger, setup_logging
@@ -85,7 +86,9 @@ async def _process_gov_actions(block_no: int) -> None:
         for w in warnings:
             logger.warning("CIP-0108 validation [%s#%s]: %s", action.tx_hash[:8], action.index, w)
 
-        tweet = format_gov_action_tweet(action, metadata)
+        thresholds = await get_gov_thresholds(action)
+
+        tweet = format_gov_action_tweet(action, metadata, thresholds)
         tweet_id = post_tweet(tweet)
         save_action_tweet_id(action.tx_hash, action.index, tweet_id or "", source_block=block_no)
 

--- a/bot/thresholds.py
+++ b/bot/thresholds.py
@@ -124,6 +124,19 @@ class EpochThresholds:
 
 
 @dataclass(frozen=True)
+class ThresholdContext:
+    """Block-level voting context shared by every action in a block.
+
+    The epoch thresholds and committee quorum are identical for all actions in a
+    block, so they are fetched once and reused (only ParameterChange group
+    detection is per-action).
+    """
+
+    params: EpochThresholds
+    committee_quorum: float | None = None
+
+
+@dataclass(frozen=True)
 class ParamChangeGroups:
     """Which protocol-parameter groups a ParameterChange action touches."""
 

--- a/bot/thresholds.py
+++ b/bot/thresholds.py
@@ -1,0 +1,224 @@
+"""Governance action ratification thresholds.
+
+Cardano ratifies a governance action only when the relevant voting bodies
+(DReps, SPOs, the Constitutional Committee) each reach a minimum approval
+ratio. Those ratios are protocol parameters (the ``dvt_*`` / ``pvt_*`` columns
+of ``epoch_param``) and the CC quorum (the ``committee`` table), so they can
+themselves be changed by governance. We therefore read the *live* values from
+DB-Sync rather than hard-coding them.
+
+Which bodies vote — and which threshold applies — depends on the action type
+(see CIP-1694). This module turns the raw DB values into a :class:`GovThresholds`
+describing only the bodies that actually vote on a given action.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Protocol-parameter groups (CIP-1694)
+#
+# A ParameterChange action's DRep threshold depends on which parameter group(s)
+# it touches, and SPOs only vote when a *security-relevant* parameter changes.
+# These tuples list the ``param_proposal`` columns belonging to each group.
+# ---------------------------------------------------------------------------
+
+NETWORK_PARAMS = (
+    "max_block_size",
+    "max_tx_size",
+    "max_bh_size",
+    "max_val_size",
+    "max_tx_ex_mem",
+    "max_tx_ex_steps",
+    "max_block_ex_mem",
+    "max_block_ex_steps",
+    "max_collateral_inputs",
+)
+
+ECONOMIC_PARAMS = (
+    "min_fee_a",
+    "min_fee_b",
+    "key_deposit",
+    "pool_deposit",
+    "monetary_expand_rate",
+    "treasury_growth_rate",
+    "min_pool_cost",
+    "coins_per_utxo_size",
+    "price_mem",
+    "price_step",
+)
+
+TECHNICAL_PARAMS = (
+    "influence",
+    "optimal_pool_count",
+    "max_epoch",
+    "collateral_percent",
+    "cost_model_id",
+    "min_fee_ref_script_cost_per_byte",
+)
+
+GOVERNANCE_PARAMS = (
+    "gov_action_lifetime",
+    "gov_action_deposit",
+    "drep_deposit",
+    "drep_activity",
+    "committee_min_size",
+    "committee_max_term_length",
+    "dvt_motion_no_confidence",
+    "dvt_committee_normal",
+    "dvt_committee_no_confidence",
+    "dvt_update_to_constitution",
+    "dvt_hard_fork_initiation",
+    "dvt_p_p_network_group",
+    "dvt_p_p_economic_group",
+    "dvt_p_p_technical_group",
+    "dvt_p_p_gov_group",
+    "dvt_treasury_withdrawal",
+    "pvt_motion_no_confidence",
+    "pvt_committee_normal",
+    "pvt_committee_no_confidence",
+    "pvt_hard_fork_initiation",
+    "pvtpp_security_group",
+)
+
+# Parameters the SPOs are entitled to vote on (the "security" group).
+SECURITY_PARAMS = (
+    "max_block_size",
+    "max_tx_size",
+    "max_bh_size",
+    "max_val_size",
+    "max_block_ex_mem",
+    "max_block_ex_steps",
+    "min_fee_a",
+    "min_fee_b",
+    "coins_per_utxo_size",
+    "gov_action_deposit",
+    "min_fee_ref_script_cost_per_byte",
+)
+
+
+@dataclass(frozen=True)
+class EpochThresholds:
+    """The governance voting thresholds in effect for an epoch.
+
+    Mirrors the ``dvt_*`` / ``pvt_*`` columns of ``epoch_param``. Each value is
+    an approval ratio in ``[0, 1]`` (or ``None`` before Conway).
+    """
+
+    dvt_motion_no_confidence: float | None = None
+    dvt_committee_normal: float | None = None
+    dvt_committee_no_confidence: float | None = None
+    dvt_update_to_constitution: float | None = None
+    dvt_hard_fork_initiation: float | None = None
+    dvt_p_p_network_group: float | None = None
+    dvt_p_p_economic_group: float | None = None
+    dvt_p_p_technical_group: float | None = None
+    dvt_p_p_gov_group: float | None = None
+    dvt_treasury_withdrawal: float | None = None
+    pvt_motion_no_confidence: float | None = None
+    pvt_committee_normal: float | None = None
+    pvt_committee_no_confidence: float | None = None
+    pvt_hard_fork_initiation: float | None = None
+    pvtpp_security_group: float | None = None
+
+
+@dataclass(frozen=True)
+class ParamChangeGroups:
+    """Which protocol-parameter groups a ParameterChange action touches."""
+
+    network: bool = False
+    economic: bool = False
+    technical: bool = False
+    governance: bool = False
+    security: bool = False
+
+
+@dataclass(frozen=True)
+class GovThresholds:
+    """Ratification thresholds applicable to a single governance action.
+
+    A body's field is ``None`` when that body does not vote on the action type.
+    ``note`` carries free text for actions with no on-chain threshold.
+    """
+
+    drep: float | None = None
+    spo: float | None = None
+    cc: float | None = None
+    note: str | None = None
+
+    @property
+    def is_empty(self) -> bool:
+        return self.drep is None and self.spo is None and self.cc is None and not self.note
+
+
+def _max(*values: float | None) -> float | None:
+    present = [v for v in values if v is not None]
+    return max(present) if present else None
+
+
+def compute_thresholds(
+    action_type: str,
+    params: EpochThresholds,
+    committee_quorum: float | None,
+    *,
+    param_groups: ParamChangeGroups | None = None,
+) -> GovThresholds:
+    """Return the thresholds that apply to ``action_type``.
+
+    ``params`` are the current epoch's voting thresholds, ``committee_quorum``
+    the active CC's approval ratio, and ``param_groups`` (ParameterChange only)
+    the protocol-parameter groups the proposal touches.
+    """
+    if action_type == "InfoAction":
+        # Info actions can be voted on but are never enacted — no threshold.
+        return GovThresholds(note="none (informational)")
+
+    if action_type == "HardForkInitiation":
+        return GovThresholds(
+            drep=params.dvt_hard_fork_initiation,
+            spo=params.pvt_hard_fork_initiation,
+            cc=committee_quorum,
+        )
+
+    if action_type == "TreasuryWithdrawals":
+        return GovThresholds(drep=params.dvt_treasury_withdrawal, cc=committee_quorum)
+
+    if action_type == "NoConfidence":
+        return GovThresholds(
+            drep=params.dvt_motion_no_confidence,
+            spo=params.pvt_motion_no_confidence,
+        )
+
+    if action_type == "NewCommittee":
+        # Thresholds differ in a state of no-confidence; the common (normal)
+        # case is shown here.
+        return GovThresholds(
+            drep=params.dvt_committee_normal,
+            spo=params.pvt_committee_normal,
+        )
+
+    if action_type == "NewConstitution":
+        return GovThresholds(drep=params.dvt_update_to_constitution, cc=committee_quorum)
+
+    if action_type == "ParameterChange":
+        groups = param_groups or ParamChangeGroups()
+        drep = _max(
+            params.dvt_p_p_network_group if groups.network else None,
+            params.dvt_p_p_economic_group if groups.economic else None,
+            params.dvt_p_p_technical_group if groups.technical else None,
+            params.dvt_p_p_gov_group if groups.governance else None,
+        )
+        if drep is None:
+            # No group detected (e.g. param_proposal missing) — fall back to a
+            # representative non-governance DRep threshold so we still show
+            # something sensible.
+            drep = params.dvt_p_p_economic_group
+        return GovThresholds(
+            drep=drep,
+            spo=params.pvtpp_security_group if groups.security else None,
+            cc=committee_quorum,
+        )
+
+    # Unknown / future action type — show nothing rather than guess.
+    return GovThresholds()

--- a/bot/twitter/formatter.py
+++ b/bot/twitter/formatter.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from bot.links import make_governance_action_link
 from bot.metadata.fetcher import sanitise_url
 from bot.models import CcVote, GovAction, TreasuryDonation
+from bot.thresholds import GovThresholds
 from bot.twitter import templates
 
 VOTES_MAPPING = {
@@ -10,6 +11,33 @@ VOTES_MAPPING = {
     "NO": "Unconstitutional",
     "ABSTAIN": "Abstain",
 }
+
+
+def _pct(ratio: float) -> str:
+    """Render a 0..1 approval ratio as a whole-number percentage, e.g. '67%'."""
+    return f"{round(ratio * 100)}%"
+
+
+def _thresholds_line(thresholds: GovThresholds | None) -> str:
+    """Build the 'Thresholds: ...' line, omitting bodies that don't vote.
+
+    Returns an empty string when no thresholds are available, so the line is
+    dropped entirely from the tweet.
+    """
+    if thresholds is None or thresholds.is_empty:
+        return ""
+    if thresholds.note:
+        return f"Thresholds: {thresholds.note}\n"
+    parts = []
+    if thresholds.drep is not None:
+        parts.append(f"DRep {_pct(thresholds.drep)}")
+    if thresholds.spo is not None:
+        parts.append(f"SPO {_pct(thresholds.spo)}")
+    if thresholds.cc is not None:
+        parts.append(f"CC {_pct(thresholds.cc)}")
+    if not parts:
+        return ""
+    return f"Thresholds: {' · '.join(parts)}\n"
 
 
 def _vote_display(vote: str) -> str:
@@ -34,7 +62,11 @@ def _authors_line(metadata: dict | None, *, label: str = "Authors", emoji: str =
     return f"{emoji_prefix}{label}: {', '.join(names)}\n"
 
 
-def format_gov_action_tweet(action: GovAction, metadata: dict | None) -> str:
+def format_gov_action_tweet(
+    action: GovAction,
+    metadata: dict | None,
+    thresholds: GovThresholds | None = None,
+) -> str:
     title = metadata.get("body", {}).get("title") if metadata else None
     title_line = f"Title: {title}\n" if title else ""
     authors_line = _authors_line(metadata, label="Authors")
@@ -43,6 +75,7 @@ def format_gov_action_tweet(action: GovAction, metadata: dict | None) -> str:
         title_line=title_line,
         authors_line=authors_line,
         action_type=action.action_type_display,
+        thresholds_line=_thresholds_line(thresholds),
         link=make_governance_action_link(action.tx_hash, action.index),
     )
 

--- a/bot/twitter/templates.py
+++ b/bot/twitter/templates.py
@@ -8,7 +8,7 @@ GOV_ACTION = """\
 Governance Action Update
 
 {title_line}{authors_line}Type: {action_type}
-Action: {link}
+{thresholds_line}Action: {link}
 """
 
 CC_VOTE = """\

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,4 +1,5 @@
 from bot.models import CcVote, GovAction, TreasuryDonation
+from bot.thresholds import GovThresholds
 from bot.twitter.formatter import (
     format_cc_vote_tweet,
     format_gov_action_tweet,
@@ -37,6 +38,31 @@ class TestFormatGovActionTweet:
         metadata = {"body": {}}
         tweet = format_gov_action_tweet(action, metadata)
         assert "Title:" not in tweet
+
+    def test_no_thresholds_omits_line(self):
+        action = self._make_action()
+        tweet = format_gov_action_tweet(action, None)
+        assert "Thresholds:" not in tweet
+
+    def test_thresholds_line_shows_applicable_bodies(self):
+        action = self._make_action()
+        thresholds = GovThresholds(drep=0.67, spo=0.51, cc=0.67)
+        tweet = format_gov_action_tweet(action, None, thresholds)
+        assert "Thresholds: DRep 67% · SPO 51% · CC 67%" in tweet
+        assert len(tweet) <= MAX_TWEET_LENGTH
+
+    def test_thresholds_line_omits_non_voting_body(self):
+        action = self._make_action(action_type="TreasuryWithdrawals")
+        thresholds = GovThresholds(drep=0.67, cc=0.67)
+        tweet = format_gov_action_tweet(action, None, thresholds)
+        assert "Thresholds: DRep 67% · CC 67%" in tweet
+        assert "SPO" not in tweet
+
+    def test_thresholds_note_for_info_action(self):
+        action = self._make_action(action_type="InfoAction")
+        thresholds = GovThresholds(note="none (informational)")
+        tweet = format_gov_action_tweet(action, None, thresholds)
+        assert "Thresholds: none (informational)" in tweet
 
 
 class TestFormatCcVoteTweet:

--- a/tests/test_main_state_store.py
+++ b/tests/test_main_state_store.py
@@ -20,7 +20,11 @@ async def test_process_gov_actions_saves_action_state(monkeypatch):
     async def _fake_get_gov_actions(*_):
         return [action]
 
+    async def _fake_get_threshold_context(*_):
+        return None
+
     monkeypatch.setattr(main, "get_gov_actions", _fake_get_gov_actions)
+    monkeypatch.setattr(main, "get_threshold_context", _fake_get_threshold_context)
     monkeypatch.setattr(main, "sanitise_url", lambda url: url)
     monkeypatch.setattr(main, "fetch_metadata", lambda *_: {"body": {"title": "t"}})
     monkeypatch.setattr(main, "validate_gov_action_rationale", lambda *_: [])

--- a/tests/test_thresholds.py
+++ b/tests/test_thresholds.py
@@ -1,0 +1,92 @@
+from bot.thresholds import (
+    EpochThresholds,
+    GovThresholds,
+    ParamChangeGroups,
+    compute_thresholds,
+)
+
+# Representative current-mainnet thresholds for exercising the mapping.
+PARAMS = EpochThresholds(
+    dvt_motion_no_confidence=0.67,
+    dvt_committee_normal=0.67,
+    dvt_committee_no_confidence=0.60,
+    dvt_update_to_constitution=0.75,
+    dvt_hard_fork_initiation=0.60,
+    dvt_p_p_network_group=0.67,
+    dvt_p_p_economic_group=0.67,
+    dvt_p_p_technical_group=0.67,
+    dvt_p_p_gov_group=0.75,
+    dvt_treasury_withdrawal=0.67,
+    pvt_motion_no_confidence=0.51,
+    pvt_committee_normal=0.51,
+    pvt_committee_no_confidence=0.51,
+    pvt_hard_fork_initiation=0.51,
+    pvtpp_security_group=0.51,
+)
+CC_QUORUM = 0.67
+
+
+class TestComputeThresholds:
+    def test_hard_fork_includes_all_three_bodies(self):
+        t = compute_thresholds("HardForkInitiation", PARAMS, CC_QUORUM)
+        assert t == GovThresholds(drep=0.60, spo=0.51, cc=0.67)
+
+    def test_treasury_withdrawal_omits_spo(self):
+        t = compute_thresholds("TreasuryWithdrawals", PARAMS, CC_QUORUM)
+        assert t.drep == 0.67
+        assert t.spo is None
+        assert t.cc == 0.67
+
+    def test_no_confidence_omits_cc(self):
+        t = compute_thresholds("NoConfidence", PARAMS, CC_QUORUM)
+        assert t.drep == 0.67
+        assert t.spo == 0.51
+        assert t.cc is None
+
+    def test_new_committee_omits_cc(self):
+        t = compute_thresholds("NewCommittee", PARAMS, CC_QUORUM)
+        assert t.drep == 0.67
+        assert t.spo == 0.51
+        assert t.cc is None
+
+    def test_new_constitution_omits_spo(self):
+        t = compute_thresholds("NewConstitution", PARAMS, CC_QUORUM)
+        assert t.drep == 0.75
+        assert t.spo is None
+        assert t.cc == 0.67
+
+    def test_info_action_has_note_and_no_bodies(self):
+        t = compute_thresholds("InfoAction", PARAMS, CC_QUORUM)
+        assert t.drep is None and t.spo is None and t.cc is None
+        assert t.note == "none (informational)"
+
+    def test_param_change_non_security_economic(self):
+        groups = ParamChangeGroups(economic=True)
+        t = compute_thresholds("ParameterChange", PARAMS, CC_QUORUM, param_groups=groups)
+        assert t.drep == 0.67
+        assert t.spo is None  # not a security-group param
+        assert t.cc == 0.67
+
+    def test_param_change_security_includes_spo(self):
+        groups = ParamChangeGroups(economic=True, security=True)
+        t = compute_thresholds("ParameterChange", PARAMS, CC_QUORUM, param_groups=groups)
+        assert t.spo == 0.51
+
+    def test_param_change_governance_group_uses_higher_drep(self):
+        groups = ParamChangeGroups(network=True, governance=True)
+        t = compute_thresholds("ParameterChange", PARAMS, CC_QUORUM, param_groups=groups)
+        # Binding threshold is the highest among touched groups.
+        assert t.drep == 0.75
+
+    def test_param_change_without_groups_falls_back(self):
+        t = compute_thresholds("ParameterChange", PARAMS, CC_QUORUM, param_groups=None)
+        assert t.drep == 0.67
+        assert t.spo is None
+
+    def test_unknown_action_type_is_empty(self):
+        t = compute_thresholds("SomethingNew", PARAMS, CC_QUORUM)
+        assert t.is_empty
+
+    def test_missing_cc_quorum_omits_cc(self):
+        t = compute_thresholds("HardForkInitiation", PARAMS, None)
+        assert t.cc is None


### PR DESCRIPTION
## Summary

Adds the required ratification **thresholds** to the tweet posted when a new governance action is detected, so followers can see at a glance what each action needs to pass.

Example output:

```
Governance Action Update

Title: Hard Fork to Protocol Version 11 ('van Rossem' Hard Fork)
Type: Hard Fork Initiation
Thresholds: DRep 60% · SPO 51% · CC 67%
Action: https://explorer.cardano.org/governance-action/...
```

## How it works

- Thresholds are read **live** from DB-Sync — the `dvt_*`/`pvt_*` columns of `epoch_param` and the active committee's quorum from the `committee` table — so they stay correct if governance ever changes them. The line is omitted (rather than showing wrong numbers) when the data is unavailable, e.g. pre-Conway.
- Per CIP-1694, only the voting bodies that actually decide a given action type are shown (e.g. SPOs are omitted for treasury withdrawals; the CC is omitted for no-confidence motions).
- **ParameterChange** is special-cased: it inspects which protocol-parameter group(s) the linked `param_proposal` touches to choose the binding DRep threshold (e.g. 75% when the governance group is touched) and to include SPOs only when a security-group parameter changes.
- `InfoAction` shows `Thresholds: none (informational)`.

## Changes

- New `bot/thresholds.py` — parameter-group definitions + `compute_thresholds()` domain logic.
- New queries in `bot/db/queries.py` (latest thresholds, active committee quorum, param-change group detection) and `get_gov_thresholds()` in `bot/db/repository.py`.
- `bot/twitter/formatter.py` / `templates.py` render the `Thresholds:` line; wired into the handler in `bot/main.py`.
- New `tests/test_thresholds.py` and extended formatter/handler tests.

## Testing

- `pytest` — all 98 tests pass.
- `ruff check` / `ruff format --check` — clean.
- Verified end-to-end against three real mainnet actions (a ParameterChange touching `committeeMinSize` -> DRep 75%, a Mithril treasury withdrawal -> DRep 67% / CC 67%, and the PV11 hard fork -> DRep 60% / SPO 51% / CC 67%) using live Koios data.

### Notes / open questions
- `NewCommittee` uses the normal-state thresholds; these differ in a state of no-confidence, which would need extra ledger-state tracking to detect.
- ParameterChange falls back to a representative non-governance DRep threshold if the `param_proposal` row can't be resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
