### PR TITLE
Fix UTF-8 metadata corruption when hosts omit charset

### DIFF
--- a/bot/metadata/fetcher.py
+++ b/bot/metadata/fetcher.py
@@ -17,6 +17,10 @@ def fetch_metadata(url: str) -> dict | None:
     try:
         response = requests.get(url, timeout=30)
         if response.status_code == 200:
+            # JSON is UTF-8 per RFC 8259. Some hosts (e.g. IPFS gateways) serve it
+            # as text/* with no charset, which makes requests default to Latin-1 and
+            # mangle non-ASCII characters. Force UTF-8 so response.json() decodes right.
+            response.encoding = "utf-8"
             return response.json()
         logger.warning("Error retrieving metadata (HTTP %s): %s", response.status_code, url)
         return None

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,4 +1,7 @@
+import json
 from unittest.mock import MagicMock, patch
+
+import requests
 
 from bot.metadata.fetcher import fetch_metadata, sanitise_url
 
@@ -27,6 +30,29 @@ class TestFetchMetadata:
 
         result = fetch_metadata("https://example.com/metadata.json")
         assert result == {"body": {"title": "Test"}}
+
+    @patch("bot.metadata.fetcher.requests.get")
+    def test_utf8_body_with_non_charset_content_type(self, mock_get):
+        """UTF-8 JSON served as text/* (no charset) must not be mangled to Latin-1.
+
+        Hosts like IPFS gateways serve JSON as text/plain without a charset, so
+        requests defaults response.encoding to ISO-8859-1. Without forcing UTF-8,
+        response.json() double-decodes non-ASCII characters into mojibake.
+        """
+        title = 'Name the Protocol Version 12 hard fork “von Bergen”'
+        body = json.dumps({"body": {"title": title}}, ensure_ascii=False)
+
+        response = requests.models.Response()
+        response.status_code = 200
+        response._content = body.encode("utf-8")
+        response.headers["Content-Type"] = "text/plain"  # no charset
+        # Mirror how requests populates encoding from the headers (-> ISO-8859-1).
+        response.encoding = requests.utils.get_encoding_from_headers(response.headers)
+        assert response.encoding == "ISO-8859-1"  # the condition that triggers the bug
+        mock_get.return_value = response
+
+        result = fetch_metadata("https://ipfs.io/ipfs/Qmwhatever")
+        assert result == {"body": {"title": title}}
 
     @patch("bot.metadata.fetcher.requests.get")
     def test_http_error(self, mock_get):

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -39,7 +39,7 @@ class TestFetchMetadata:
         requests defaults response.encoding to ISO-8859-1. Without forcing UTF-8,
         response.json() double-decodes non-ASCII characters into mojibake.
         """
-        title = 'Name the Protocol Version 12 hard fork “von Bergen”'
+        title = "Name the Protocol Version 12 hard fork “von Bergen”"
         body = json.dumps({"body": {"title": title}}, ensure_ascii=False)
 
         response = requests.models.Response()


### PR DESCRIPTION
## What

Force UTF-8 decoding of governance-action metadata in `bot/metadata/fetcher.py`, and add a regression test.

## Why

Cloud Run logs showed garbled titles/authors like `Name the Protocol Version 12 hard fork âvon Bergenâ` and `Ambassadors â submitted by Chris [STR8]`.

This is **mojibake**, not a display quirk: metadata is fetched with `requests`, and some hosts (IPFS gateways especially) serve the JSON as `text/plain`/`text/html` with **no charset**. Per the old HTTP spec, `requests` then defaults `response.encoding` to `ISO-8859-1`, so `response.json()` double-decodes the UTF-8 bytes into Latin-1 — mangling curly quotes (`“ ”`) and em-dashes (`—`).

The corrupted string lands inside the parsed dict, so it reached **both the logs and the actual posted tweets** (the formatter reads the same `metadata["body"]["title"]`).

## Fix

JSON is required to be UTF-8 (RFC 8259), so set `response.encoding = "utf-8"` before `response.json()`.

```python
if response.status_code == 200:
    response.encoding = "utf-8"
    return response.json()
```

## Test

Added `test_utf8_body_with_non_charset_content_type`, which builds a **real** `requests.Response` (a `MagicMock` can't reproduce the encoding path) simulating a `text/plain` UTF-8 body. Verified it fails without the fix (reproducing the exact `â\x80\x9c…` mojibake) and passes with it. Full `test_fetcher.py` suite: 7 passed.

## Reviewer notes

- Worth spot-checking recently posted governance-action tweets — actions posted before this fix may have gone out with garbled characters and can't be corrected by this change.
- The container (`python:3.12-slim`) sets no `LANG`/locale, but Python 3.12's PEP 540 UTF-8 mode handles stdout, so that was not the cause. Adding `ENV PYTHONUTF8=1` to the Dockerfile as belt-and-suspenders is optional and left out of this PR.